### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 feedparser
+python-dateutil


### PR DESCRIPTION
python-dateutil should be installed
python v3.x doesn't contain dateutil package